### PR TITLE
Simplify serialization

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -1,12 +1,29 @@
 use std::collections::{HashMap, BTreeSet};
 use iron::typemap::Key;
 use model::{CheckModel, GuessModel};
+use serde::ser::{Serialize, Serializer};
 
-#[derive(Eq, PartialEq, Serialize)]
+#[derive(Eq, PartialEq)]
 pub enum Outcome {
     InProgress,
     Lost,
     Won,
+}
+
+impl AsRef<str> for Outcome {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Outcome::InProgress => "InProgress",
+            Outcome::Lost => "Lost",
+            Outcome::Won => "Won",
+        }
+    }
+}
+
+impl Serialize for Outcome {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.serialize_str(self.as_ref())
+    }
 }
 
 pub struct Game {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 extern crate iron;
 extern crate persistent;
 extern crate rand;
+extern crate serde;
 extern crate serde_json;
 
 mod error;


### PR DESCRIPTION
Serialize `Outcome` as a string rather than as an empty json object.
