### PR TITLE
Close too-many-guesses dos vector

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, BTreeSet};
 use iron::typemap::Key;
-use model::{CheckModel, GuessModel};
+use model::GameStateModel;
 use serde::ser::{Serialize, Serializer};
 
 #[derive(Eq, PartialEq)]
@@ -41,21 +41,20 @@ impl Game {
         }
     }
     
-    pub fn check(&self) -> CheckModel {
-        CheckModel {
+    pub fn check(&self) -> GameStateModel {
+        GameStateModel {
+            success: None,
             outcome: self.outcome(),
             state: self.build_state_string(),
-            guesses: self.guesses_as_vec(),
             strike_count: self.strike_count,
         }
     }
     
-    pub fn guess(&mut self, guess: &str) -> GuessModel {
+    pub fn guess(&mut self, guess: &str) -> GameStateModel {
         match guess.chars().nth(0) {
-            None => GuessModel {
-                success: false,
+            None => GameStateModel {
+                success: Some(false),
                 state: self.build_state_string(),
-                guesses: self.guesses_as_vec(),
                 strike_count: {
                     self.strike_count += 1;
                     self.strike_count
@@ -65,10 +64,9 @@ impl Game {
             Some(guess) => {
                 let success = self.word.chars().any(|c| c == guess);
                 self.guesses.insert(guess);
-                GuessModel {
-                    success: success,
+                GameStateModel {
+                    success: Some(success),
                     state: self.build_state_string(),
-                    guesses: self.guesses_as_vec(),
                     strike_count: {
                         if !success {
                             self.strike_count += 1;
@@ -87,10 +85,6 @@ impl Game {
         } else {
             '_'
         }).collect()
-    }
-    
-    fn guesses_as_vec(&self) -> Vec<char> {
-        self.guesses.iter().cloned().collect()
     }
     
     pub fn outcome(&self) -> Outcome {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,35 +1,16 @@
 use game::Outcome;
 
 #[derive(Serialize)]
-pub struct CheckModel {
-    #[serde(rename = "State")]
-    pub state: String,
-    
-    #[serde(rename = "Outcome")]
-    pub outcome: Outcome,
-    
-    #[serde(rename = "Guesses")]
-    #[serde(skip_serializing_if="Vec::is_empty")]
-    pub guesses: Vec<char>,
-    
-    #[serde(rename = "StrikeCount")]
-    pub strike_count: i32,
-}
-
-#[derive(Serialize)]
-pub struct GuessModel {
+pub struct GameStateModel {
     #[serde(rename = "Success")]
-    pub success: bool,
-    
-    #[serde(rename = "Outcome")]
-    pub outcome: Outcome,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub success: Option<bool>,
     
     #[serde(rename = "State")]
     pub state: String,
     
-    #[serde(rename = "Guesses")]
-    #[serde(skip_serializing_if="Vec::is_empty")]
-    pub guesses: Vec<char>,
+    #[serde(rename = "Outcome")]
+    pub outcome: Outcome,
     
     #[serde(rename = "StrikeCount")]
     pub strike_count: i32,


### PR DESCRIPTION
It's possible for someone to make a zillion guesses and then have us trying to push them a zillion guesses in a vector every time they make a request. This is not good.

This patch closes this dos vector by removing guesses from the state response. As an added bonus, we went from two different state response models to one.
