### PR TITLE
Allow difficulty configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "hangman-server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "clap 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.65 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hangman-server"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["J/A <archer884@gmail.com>"]
 
 [dependencies]
-clap = "*"
+clap = { version = "*", features = ["unstable", "suggestions", "color"] }
 clippy = "*"
 iron = "*"
 persistent = "*"

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,51 @@
+use clap::ArgMatches;
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum Difficulty {
+    Hard,
+    Normal,
+    Easy,
+}
+
+pub struct Options {
+    path: Option<String>,
+    difficulty: Difficulty,
+}
+
+impl Options {
+    pub fn read() -> Options {
+        let matches = get_matches();
+        Options {
+            path: matches.value_of("path").map(|path| path.to_owned()),
+            difficulty: if matches.is_present("hard") {
+                Difficulty::Hard
+            } else if matches.is_present("easy") {
+                Difficulty::Easy
+            } else {
+                Difficulty::Normal
+            }
+        }
+    }
+
+    pub fn path(&self) -> Option<&String> {
+        self.path.as_ref()
+    }
+
+    pub fn difficulty(&self) -> Difficulty {
+        self.difficulty
+    }
+}
+
+fn get_matches<'a>() -> ArgMatches<'a> {
+    clap_app!(myapp =>
+        (version: crate_version!())
+        (author: crate_authors!())
+        (about: "A RESTful-ish Hangman service")
+        (@arg path: "Dictionary path")
+        (@group difficulty =>
+            (@arg hard: -h --hard "Sets hard mode")
+            (@arg normal: -n --normal "Sets normal mode")
+            (@arg easy: -e --easy "Sets easy mode")
+        )
+    ).get_matches()
+}

--- a/src/words.rs
+++ b/src/words.rs
@@ -1,11 +1,31 @@
 use std::ascii::AsciiExt;
 use std::collections::BTreeSet;
+use std::cmp::Ordering;
 use iron::typemap::Key;
+use options::Difficulty;
+use ranking::{CommonalityRanker, Ranker};
 
 pub struct WordList;
 
 impl Key for WordList {
     type Value = Vec<String>;
+}
+
+pub fn select_by_difficulty(difficulty: Difficulty, word_list: Vec<String>) -> Vec<String> {
+    match difficulty {
+        Difficulty::Normal => word_list,
+        Difficulty::Easy => select(word_list, |a, b| b.cmp(&a)),
+        Difficulty::Hard => select(word_list, |a, b| a.cmp(&b)),
+    }
+}
+
+fn select<F: Fn(i32, i32) -> Ordering>(word_list: Vec<String>, cmp: F) -> Vec<String> {
+    let ranker = CommonalityRanker::new(&word_list);
+    let mut ranked_word_list: Vec<_> = word_list.iter().map(|word| (word, ranker.score_word(word))).collect();
+    
+    ranked_word_list.sort_by(|&(_, a), &(_, b)| cmp(a, b));
+    
+    ranked_word_list.iter().take(word_list.len() / 3).map(|&(word, _)| word.to_owned()).collect()
 }
 
 pub fn validate_word(s: &str) -> bool {


### PR DESCRIPTION
Using clap for command parsing, it is now possible to request a harder or easier game at the command line. Unfortunately, this configuration is only possible at the beginning of the game.

Might be a good idea to allow the user to request harder or easier words at runtime.
